### PR TITLE
Add support for laravel 5.2 model controller

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,13 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "Illuminate/Support": "5.3.*"
+        "laravel/framework": "5.3.*"
     },
     "autoload": {
         "psr-4": {
             "Kyslik\\ArtisanStubs\\": "src/ArtisanStubs/"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/src/ArtisanStubs/ControllerMakeCommand.php
+++ b/src/ArtisanStubs/ControllerMakeCommand.php
@@ -19,7 +19,9 @@ class ControllerMakeCommand extends ControllerMakeCommandOriginal
      */
     protected function getStub()
     {
-        if ($this->option('resource')) {
+        if ($this->option('model')) {
+            return $this->checkStub('/stubs/routing/controller.model.stub');
+        } elseif ($this->option('resource')) {
             return $this->checkStub('/stubs/routing/controller.stub');
         }
 

--- a/src/stubs/routing/controller.model.stub
+++ b/src/stubs/routing/controller.model.stub
@@ -1,0 +1,86 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyFullModelClass;
+use Illuminate\Http\Request;
+use DummyRootNamespaceHttp\Controllers\Controller;
+
+class DummyClass extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \DummyFullModelClass  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function show(DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \DummyFullModelClass  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \DummyFullModelClass  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \DummyFullModelClass  $DummyModelVariable
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(DummyModelClass $DummyModelVariable)
+    {
+        //
+    }
+}


### PR DESCRIPTION
This branch adds support for `artisan make:controller --model` introduced in Laravel 5.2

Fixes #1 