### PR TITLE
fix #3 override in MigrationCreator for Laravel 5.4

### DIFF
--- a/src/ArtisanStubs/MigrationCreator.php
+++ b/src/ArtisanStubs/MigrationCreator.php
@@ -12,6 +12,11 @@ class MigrationCreator extends MigrationCreatorOriginal
 {
     use CheckStub;
 
+    public function stubPath()
+    {
+        return $this->getStubPath();
+    }
+
     /**
      * Get the path to the stubs.
      *


### PR DESCRIPTION
This fixes #3 by overriding methods in both Laravel 5.3 and 5.4